### PR TITLE
Fixed typos, added missing return, corrected facts

### DIFF
--- a/vscode.lua
+++ b/vscode.lua
@@ -95,7 +95,8 @@ function matrix.multiplyXYZW(matrix1, x, y, z, w) end
 
 --- Returns the rotation required to face an X Z vector
 --- @param x number 
---- @param z number 
+--- @param z number
+--- @return number required_rotation
 function matrix.rotationToFaceXZ(x, z) end
 
 
@@ -1370,12 +1371,12 @@ function server.despawnVehicle(vehicle_id, is_instant) end
 --- @return SWMatrix matrix, boolean is_success
 function server.getVehiclePos(vehicle_id, voxel_x, voxel_y, voxel_z) end
 
---- Teleports a vehicle from it's current locaiton to the new matrix
+--- Teleports a vehicle from it's current location to the new matrix
 --- @param vehicle_id number The unique id of the vehicle
 --- @param matrix SWMatrix The matrix to be applied to the vehicle
 function server.setVehiclePos(vehicle_id, matrix) end
 
---- Teleports a vehicle from it's current locaiton to the new matrix. The vehicle is displaced by other vehicles at the arrival point
+--- Teleports a vehicle from it's current location to the new matrix. The vehicle is displaced by other vehicles at the arrival point
 --- @param vehicle_id number The unique id of the vehicle
 --- @param matrix SWMatrix The matrix to be applied to the vehicle
 function server.setVehiclePosSafe(vehicle_id, matrix) end
@@ -1550,7 +1551,8 @@ function server.getVehicleFireCount(vehicle_id) end
 --- @return boolean is_success
 function server.setVehicleTooltip(vehicle_id, text) end
 
---- Applies impact damage to a vehicle at the specified voxel location (cannot use negative values, so cannot repair.)
+--- Applies impact damage to a vehicle at the specified voxel location
+--- <br>Negative values repair the vehicles instead of damaging it
 --- @param vehicle_id number The ID of the vehicle to apply damage to
 --- @param amount number The amount of damage to apply (0-100)
 --- @param voxel_x number The voxel's X position to apply damage to


### PR DESCRIPTION
Title explains - basically just some minor modifications
- Typos with the word "location"
- Missing return statement in `matrix#rotationToFaceXZ`
- Updated `server#addDamage` as it now supports repairing the vehicle by inputting a negative value (see https://steamdb.info/patchnotes/12201065/)